### PR TITLE
Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ data-engine/
 1. Domain generation.  
    Options for `type`: organization, algorithm, flowchart, dashboard.
     ```bash
-    python boostrap_domains.py --type xxx
+    python bootstrap_domains.py --type xxx
     ```
    
 2. Data and plots generation.  


### PR DESCRIPTION
In `Multi-modal-Self-instruct/README.md`,

There is a typo in the following section.
- Abstract Image Generation
   - Domain generation.

The file name `bootstrap_domains.py` is misspelled to `boostrap_domains`.